### PR TITLE
Expose program arguments and session started signal to QML

### DIFF
--- a/src/ksession.cpp
+++ b/src/ksession.cpp
@@ -32,6 +32,7 @@
 KSession::KSession(QObject *parent) :
     QObject(parent), m_session(createSession(""))
 {
+    connect(m_session, SIGNAL(started()), this, SIGNAL(started()));
     connect(m_session, SIGNAL(finished()), this, SLOT(sessionFinished()));
     connect(m_session, SIGNAL(titleChanged()), this, SIGNAL(titleChanged()));
 }

--- a/src/ksession.h
+++ b/src/ksession.h
@@ -38,6 +38,7 @@ class KSession : public QObject
     Q_PROPERTY(QString  initialWorkingDirectory READ getInitialWorkingDirectory WRITE setInitialWorkingDirectory)
     Q_PROPERTY(QString  title READ getTitle NOTIFY titleChanged)
     Q_PROPERTY(QString  shellProgram WRITE setShellProgram)
+    Q_PROPERTY(QStringList  shellProgramArgs WRITE setArgs)
 
 public:
     KSession(QObject *parent = 0);

--- a/src/ksession.h
+++ b/src/ksession.h
@@ -89,6 +89,7 @@ public:
     QString getTitle();
 
 signals:
+    void started();
     void finished();
     void copyAvailable(bool);
 


### PR DESCRIPTION
Write access to shell program arguments is required if one wants to launch arbitrary programs without wrapping them in a shell instance.

The `onStarted` signal is useful if one wants to react to the contained application actually being started.