### PR TITLE
Exposed search to the session object.

### DIFF
--- a/src/ksession.cpp
+++ b/src/ksession.cpp
@@ -28,6 +28,7 @@
 
 // Konsole
 #include "KeyboardTranslator.h"
+#include "HistorySearch.h"
 
 KSession::KSession(QObject *parent) :
     QObject(parent), m_session(createSession(""))
@@ -208,7 +209,15 @@ void KSession::sendKey(int rep, int key, int mod) const
 //    while (rep > 0){
 //        m_session->sendKey(&qkey);
 //        --rep;
-//    }
+    //    }
+}
+
+void KSession::search(const QString &regexp, int startLine, int startColumn, bool forwards)
+{
+    HistorySearch *history = new HistorySearch( QPointer<Emulation>(m_session->emulation()), QRegExp(regexp), forwards, startColumn, startLine, this);
+    connect( history, SIGNAL(matchFound(int,int,int,int)), this, SIGNAL(matchFound(int,int,int,int)));
+    connect( history, SIGNAL(noMatchFound()), this, SIGNAL(noMatchFound()));
+    history->search();
 }
 
 void KSession::setFlowControlEnabled(bool enabled)

--- a/src/ksession.h
+++ b/src/ksession.h
@@ -99,7 +99,8 @@ signals:
     void changedKeyBindings(QString kb);
 
     void titleChanged();
-
+    void matchFound(int startColumn, int startLine, int endColumn, int endLine);
+    void noMatchFound();
 
 public slots:
     /*! Set named key binding for given widget
@@ -123,6 +124,8 @@ public slots:
     // Send some text to terminal
     void sendKey(int rep, int key, int mod) const;
 
+    // Search history
+    void search(const QString &regexp, int startLine = 0, int startColumn = 0, bool forwards = true );
 
 protected slots:
     void sessionFinished();

--- a/test-app/test-app.qml
+++ b/test-app/test-app.qml
@@ -20,11 +20,17 @@ Rectangle {
         id: terminal
         anchors.fill: parent
         font.family: "Monospace"
-        font.pointSize: 12 
+        font.pointSize: 12
         colorScheme: "cool-retro-term"
         session: QMLTermSession{
-	    id: mainsession
+            id: mainsession
             initialWorkingDirectory: "$HOME"
+            onMatchFound: {
+                console.log("found at: %1 %2 %3 %4".arg(startColumn).arg(startLine).arg(endColumn).arg(endLine));
+            }
+            onNoMatchFound: {
+                console.log("not found");
+            }
         }
         onTerminalUsesMouseChanged: console.log(terminalUsesMouse);
         onTerminalSizeChanged: console.log(terminalSize);
@@ -40,6 +46,15 @@ Rectangle {
                 anchors.fill: parent
             }
         }
+
+    }
+
+    Button {
+        text: "Find version"
+        height: 32
+        width: 48
+        onClicked: mainsession.search("version");
+
     }
     Component.onCompleted: terminal.forceActiveFocus();
 }


### PR DESCRIPTION
This will allow the caller to get the row/column of a match at the
offset.  This also exposes the signals from the HistorySearch object so
that offests can be performed.

Internally the String is converted to a QRegExp so QRegExp style regular
expressions can be used for searching the history.