### PR TITLE
Expose complete history to QML

### DIFF
--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -296,6 +296,11 @@ void Emulation::writeToStream( TerminalCharacterDecoder* _decoder ,
   _currentScreen->writeLinesToStream(_decoder,startLine,endLine);
 }
 
+void Emulation::writeToStream( TerminalCharacterDecoder* _decoder)
+{
+  _currentScreen->writeLinesToStream(_decoder, 0, _currentScreen->getHistLines());
+}
+
 int Emulation::lineCount() const
 {
     // sum number of lines currently on _screen plus number of lines in history

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -171,7 +171,17 @@ public:
    * @param endLine Index of last line to copy
    */
   virtual void writeToStream(TerminalCharacterDecoder* decoder,int startLine,int endLine);
-  
+
+  /**
+   * Copies the complete output history into @p stream, using @p decoder to convert
+   * the terminal characters into text.
+   *
+   * @param decoder A decoder which converts lines of terminal characters with
+   * appearance attributes into output text.  PlainTextDecoder is the most commonly
+   * used decoder.
+   */
+  virtual void writeToStream(TerminalCharacterDecoder* decoder);
+
   /** Returns the codec used to decode incoming characters.  See setCodec() */
   const QTextCodec* codec() const { return _codec; }
   /** Sets the codec used to decode incoming characters.  */

--- a/src/ksession.cpp
+++ b/src/ksession.cpp
@@ -209,6 +209,19 @@ int KSession::historySize() const
     }
 }
 
+QString KSession::getHistory() const
+{
+    QString history;
+    QTextStream historyStream(&history);
+    PlainTextDecoder historyDecoder;
+
+    historyDecoder.begin(&historyStream);
+    m_session->emulation()->writeToStream(&historyDecoder);
+    historyDecoder.end();
+
+    return history;
+}
+
 void KSession::sendText(QString text)
 {
     m_session->sendText(text);
@@ -225,6 +238,11 @@ void KSession::sendKey(int rep, int key, int mod) const
 //        m_session->sendKey(&qkey);
 //        --rep;
     //    }
+}
+
+void KSession::clearScreen()
+{
+    m_session->emulation()->clearEntireScreen();
 }
 
 void KSession::search(const QString &regexp, int startLine, int startColumn, bool forwards)

--- a/src/ksession.h
+++ b/src/ksession.h
@@ -39,6 +39,7 @@ class KSession : public QObject
     Q_PROPERTY(QString  title READ getTitle WRITE setTitle NOTIFY titleChanged)
     Q_PROPERTY(QString  shellProgram WRITE setShellProgram)
     Q_PROPERTY(QStringList  shellProgramArgs WRITE setArgs)
+    Q_PROPERTY(QString  history READ getHistory)
 
 public:
     KSession(QObject *parent = 0);
@@ -67,6 +68,8 @@ public:
     // History size for scrolling
     void setHistorySize(int lines); //infinite if lines < 0
     int historySize() const;
+
+    QString getHistory() const;
 
     // Sets whether flow control is enabled
     void setFlowControlEnabled(bool enabled);
@@ -131,6 +134,8 @@ public slots:
     void sendText(QString text);
     // Send some text to terminal
     void sendKey(int rep, int key, int mod) const;
+
+    void clearScreen();
 
     // Search history
     void search(const QString &regexp, int startLine = 0, int startColumn = 0, bool forwards = true );


### PR DESCRIPTION
The use case for this functionality is to be able to e.g. display the terminal application's output after it was terminated. 
This may require a manual screen flush on the QML side which is why a `clearScreen` method is also exposed. In theory this could also be done in `getHistory` but would lead to it loosing constness which is why I chose this approach.