### PR TITLE
QMAKE_POST_LINK doesn't work in Qt 5.5.

### DIFF
--- a/qmltermwidget.pro
+++ b/qmltermwidget.pro
@@ -25,12 +25,6 @@ OTHER_FILES += \
     test-app/test-app.qml \
     src/qmldir
 
-# Copy the files useful to the plugin in DESTDIR
-QMAKE_POST_LINK = $(COPY_DIR) $$PWD/lib/color-schemes $$DESTDIR && \
-    $(COPY_DIR) $$PWD/lib/kb-layouts $$DESTDIR && \
-    $$QMAKE_COPY $$PWD/src/qmldir $$DESTDIR && \
-    $$QMAKE_COPY $$PWD/src/QMLTermScrollbar.qml $$DESTDIR
-
 #########################################
 ## INTALLS
 #########################################
@@ -49,4 +43,17 @@ assets.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 qmldir.files += $$PWD/src/qmldir
 qmldir.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
-INSTALLS += target qmldir assets
+colorschemes.files = $$PWD/lib/color-schemes/*
+colorschemes.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes
+colorschemes2.files = $$PWD/lib/color-schemes/historic/*
+colorschemes2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes/historic
+
+kblayouts.files = $$PWD/lib/kb-layouts/*
+kblayouts.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts
+kblayouts2.files = $$PWD/lib/kb-layouts/historic/*
+kblayouts2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts/historic
+
+scrollbar.files = $$PWD/src/QMLTermScrollbar.qml
+scrollbar.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
+
+INSTALLS += target qmldir assets colorschemes colorschemes2 kblayouts kblayouts2 scrollbar


### PR DESCRIPTION
Replace QMAKE_POST_LINK with more extensive usage of INSTALLS.

Tested with Qt 5.5.1 on OpenBSD/amd64 and cool-retro-term 1.0.0.
