### PR TITLE
Expose current session dir

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -937,6 +937,18 @@ QString Session::foregroundProcessName()
     return name;
 }
 
+QString Session::currentDir() 
+{
+    QString path;
+    if (updateForegroundProcessInfo()) {
+        bool ok = false;
+        path= _foregroundProcessInfo->currentDir(&ok);
+        if (!ok)
+            path.clear();
+    }
+    return path;
+}
+
 bool Session::updateForegroundProcessInfo()
 {
     Q_ASSERT(_shellProcess);

--- a/lib/Session.h
+++ b/lib/Session.h
@@ -330,6 +330,11 @@ public:
      */
     QString foregroundProcessName();
 
+    /**
+     * Returns the current working directory of the process.
+     */
+    QString currentDir();
+
     /** Returns the terminal session's window size in lines and columns. */
     QSize size();
     /**

--- a/src/ksession.cpp
+++ b/src/ksession.cpp
@@ -307,3 +307,8 @@ QString KSession::foregroundProcessName()
 {
     return m_session->foregroundProcessName();
 }
+
+QString KSession::currentDir() 
+{
+    return m_session->currentDir();
+}

--- a/src/ksession.h
+++ b/src/ksession.h
@@ -42,6 +42,7 @@ class KSession : public QObject
     Q_PROPERTY(QString  history READ getHistory)
     Q_PROPERTY(bool hasActiveProcess READ hasActiveProcess)
     Q_PROPERTY(QString foregroundProcessName READ foregroundProcessName)
+    Q_PROPERTY(QString currentDir READ currentDir)
 
 public:
     KSession(QObject *parent = 0);
@@ -104,6 +105,11 @@ public:
      * Returns the name of the terminal's foreground process.
      */
     QString foregroundProcessName();
+
+    /**
+     * Returns the current working directory of the process.
+     */
+    QString currentDir();
 
 signals:
     void started();

--- a/test-app/test-app.qml
+++ b/test-app/test-app.qml
@@ -21,6 +21,13 @@ Rectangle {
         shortcut: "Ctrl+F"
     }
 
+    Action{
+        onTriggered:{
+            console.log('open new terminal window in:'+mainsession.currentDir)
+        }
+        shortcut: "Ctrl+Shift+T"
+    }
+
     QMLTermWidget {
         id: terminal
         anchors.fill: parent


### PR DESCRIPTION
I exposed the current working directory from the session to QML. Because I want to open a new terminal from the current working directory like what people can do in gnome-terminal.
