### PR TITLE
Correct scrollUp behavior

### DIFF
--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -728,13 +728,18 @@ QRect Screen::lastScrolledRegion() const
 
 void Screen::scrollUp(int from, int n)
 {
-    if (n <= 0 || from + n > _bottomMargin) return;
+    if (n <= 0)
+        return;
+    if (from > _bottomMargin)
+        return;
+    if (from + n > _bottomMargin)
+        n = _bottomMargin + 1 - from;
 
     _scrolledLines -= n;
     _lastScrolledRegion = QRect(0,_topMargin,columns-1,(_bottomMargin-_topMargin));
 
     //FIXME: make sure `topMargin', `bottomMargin', `from', `n' is in bounds.
-    moveImage(loc(0,from),loc(0,from+n),loc(columns-1,_bottomMargin));
+    moveImage(loc(0,from),loc(0,from+n),loc(columns,_bottomMargin));
     clearImage(loc(0,_bottomMargin-n+1),loc(columns-1,_bottomMargin),' ');
 }
 


### PR DESCRIPTION
CSI S escape sequence (SU, scroll up) ignored if number of lines to
scroll bigger than scrollable lines

REVIEW: https://git.reviewboard.kde.org/r/130133
BUG: https://bugs.kde.org/379318

(cherry-picked from commit 7ff23512fd6c6af1dba87083446f85baf75e9c71)