### PR TITLE
TerminalCharacterDecoder.cpp: fix build failure against gcc-10

### DIFF
--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -19,6 +19,9 @@
     02110-1301  USA.
 */
 
+// System
+#include <cwctype> /* std::iswspace */
+
 // Own
 #include "TerminalCharacterDecoder.h"
 


### PR DESCRIPTION
gcc-10 fixed a few transitive includes and std::cwctype does not
get included implicitly via other headers. This leads to the
following build error:

```
lib/TerminalCharacterDecoder.cpp: In member function
  'virtual void Konsole::HTMLDecoder::decodeLine(const Konsole::Character*,
      int, Konsole::LineProperty)':
lib/TerminalCharacterDecoder.cpp:205:18:
  error: 'iswspace' is not a member of 'std'; did you mean 'isspace'?
  205 |         if (std::iswspace(ch))
      |                  ^~~~~~~~
      |                  isspace
make: *** [Makefile:924: TerminalCharacterDecoder.o] Error 1
```

The fix is to include <cwctype> that is supposed to define 'std::iswspace'.