### PR TITLE
Fix missing includes

### DIFF
--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -22,6 +22,9 @@
 // Own
 #include "TerminalCharacterDecoder.h"
 
+// stdlib
+#include <cwctype>
+
 // Qt
 #include <QTextStream>
 


### PR DESCRIPTION
Hi, I maintain the `qmltermwidget` package in Fedora. During our Mass Rebuild of packages for the upcoming Fedora 32, `qmltermwidget`'s build failed under GCC 10.0.1. With this patch, everything works fine.

This changeset fixes a missing `#include` in `TerminalCharacterDecoder.cpp`. 