### PR TITLE
TerminalDisplay: ability to simulate a key sequence

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3408,6 +3408,16 @@ void TerminalDisplay::simulateKeyPress(int key, int modifiers, bool pressed, qui
     keyPressedSignal(&event);
 }
 
+void TerminalDisplay::simulateKeySequence(const QKeySequence &keySequence)
+{
+    for (int i = 0; i < keySequence.count(); ++i) {
+        const Qt::Key key = Qt::Key(keySequence[i] & ~Qt::KeyboardModifierMask);
+        const Qt::KeyboardModifiers modifiers = Qt::KeyboardModifiers(keySequence[i] & Qt::KeyboardModifierMask);
+        QKeyEvent eventPress = QKeyEvent(QEvent::KeyPress, key, modifiers, "");
+        keyPressedSignal(&eventPress);
+    }
+}
+
 void TerminalDisplay::simulateWheel(int x, int y, int buttons, int modifiers, QPointF angleDelta){
     QWheelEvent event(QPointF(x,y), angleDelta.y(), (Qt::MouseButton) buttons, (Qt::KeyboardModifier) modifiers);
     wheelEvent(&event);

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -550,6 +550,7 @@ public slots:
     QStringList availableColorSchemes();
 
     void simulateKeyPress(int key, int modifiers, bool pressed, quint32 nativeScanCode, const QString &text);
+    void simulateKeySequence(const QKeySequence &sequence);
     void simulateWheel(int x, int y, int buttons, int modifiers, QPointF angleDelta);
     void simulateMouseMove(int x, int y, int button, int buttons, int modifiers);
     void simulateMousePress(int x, int y, int button, int buttons, int modifiers);


### PR DESCRIPTION
This simplifies injection of shortcuts (like Ctrl+R, ..) from the outside

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>