### PR TITLE
qmltermwidget.pro: don't install asset directories twice

### DIFF
--- a/qmltermwidget.pro
+++ b/qmltermwidget.pro
@@ -43,17 +43,4 @@ assets.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 qmldir.files += $$PWD/src/qmldir
 qmldir.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
-colorschemes.files = $$PWD/lib/color-schemes/*
-colorschemes.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes
-colorschemes2.files = $$PWD/lib/color-schemes/historic/*
-colorschemes2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes/historic
-
-kblayouts.files = $$PWD/lib/kb-layouts/*
-kblayouts.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts
-kblayouts2.files = $$PWD/lib/kb-layouts/historic/*
-kblayouts2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts/historic
-
-scrollbar.files = $$PWD/src/QMLTermScrollbar.qml
-scrollbar.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
-
-INSTALLS += target qmldir assets colorschemes colorschemes2 kblayouts kblayouts2 scrollbar
+INSTALLS += target qmldir assets


### PR DESCRIPTION
* it's already installed by:
  assets.files += $$PLUGIN_ASSETS
  assets.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
  above, causing:
  Error copying 0.14.1+gitAUTOINC+59f967d5e1-r0/git/lib/kb-layouts/historic/vt100.keytab to 0.14.1+gitAUTOINC+59f967d5e1-r0/image/usr/lib/qml/QMLTermWidget/kb-layouts/historic/vt100.keytab: Destination file exists

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>