### PR TITLE
Fix "make -j8 install"

### DIFF
--- a/qmltermwidget.pro
+++ b/qmltermwidget.pro
@@ -43,17 +43,13 @@ assets.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 qmldir.files += $$PWD/src/qmldir
 qmldir.path += $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
-colorschemes.files = $$PWD/lib/color-schemes/*
-colorschemes.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes
-colorschemes2.files = $$PWD/lib/color-schemes/historic/*
-colorschemes2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/color-schemes/historic
+colorschemes.files = $$PWD/lib/color-schemes
+colorschemes.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
-kblayouts.files = $$PWD/lib/kb-layouts/*
-kblayouts.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts
-kblayouts2.files = $$PWD/lib/kb-layouts/historic/*
-kblayouts2.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH/kb-layouts/historic
+kblayouts.files = $$PWD/lib/kb-layouts
+kblayouts.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
 scrollbar.files = $$PWD/src/QMLTermScrollbar.qml
 scrollbar.path = $$INSTALL_DIR/$$PLUGIN_IMPORT_PATH
 
-INSTALLS += target qmldir assets colorschemes colorschemes2 kblayouts kblayouts2 scrollbar
+INSTALLS += target qmldir assets colorschemes kblayouts scrollbar


### PR DESCRIPTION
I was getting errors like
Error copying qmltermwidget/lib/kb-layouts/historic/x11r5.keytab to <qt_prefix>/qml/QMLTermWidget/kb-layouts/historic/x11r5.keytab: Destination file exists

because the "*" was already copying all of the "historic" subdir in parallel to the
other rule copying historic/* files one by one.

We don't even need to use "*" at all, better let qmake do the copying of
the whole directory.