### PR TITLE
Only set env var related to keyboard layout and color scheme if not set

### DIFF
--- a/src/qmltermwidget_plugin.cpp
+++ b/src/qmltermwidget_plugin.cpp
@@ -32,7 +32,9 @@ void QmltermwidgetPlugin::initializeEngine(QQmlEngine *engine, const char *uri)
             if (QDir(cs).exists()) break;
         }
 
-        setenv("KB_LAYOUT_DIR",kbl.toUtf8().constData(),1);
-        setenv("COLORSCHEMES_DIR",cs.toUtf8().constData(),1);
+        if (qEnvironmentVariableIsEmpty("KB_LAYOUT_DIR"))
+            setenv("KB_LAYOUT_DIR",kbl.toUtf8().constData(),1);
+        if (qEnvironmentVariableIsEmpty("COLORSCHEMES_DIR"))
+            setenv("COLORSCHEMES_DIR",cs.toUtf8().constData(),1);
     }
 }


### PR DESCRIPTION
This is a possible suggestion for a workaround of [this issue](https://github.com/Swordfish90/cool-retro-term/issues/676) in the cool-retro-term repo. What do you think? The only thing it does is not overwrite those environment variables if they have already been set, allowing users to specify their own directories for keytabs, for example.