### PR TITLE
Expose colorscheme, scrollbar, clipboard functionality to QML

### DIFF
--- a/lib/ColorScheme.h
+++ b/lib/ColorScheme.h
@@ -45,15 +45,16 @@ namespace Konsole
  * The color scheme includes the palette of colors used to draw the text and character backgrounds
  * in the display and the opacity level of the display background.
  */
-class ColorScheme
+class ColorScheme : public QObject
 {
+    Q_OBJECT
+
 public:
     /**
      * Constructs a new color scheme which is initialised to the default color set
      * for Konsole.
      */
-    ColorScheme();
-    ColorScheme(const ColorScheme& other);
+    ColorScheme(QObject *parent = nullptr);
     ~ColorScheme();
 
     /** Sets the descriptive name of the color scheme. */
@@ -74,6 +75,7 @@ public:
     void write(KConfig& config) const;
 #endif
     void read(const QString & filename);
+    Q_INVOKABLE void write(const QString & filename) const;
 
     /** Sets a single entry within the color palette. */
     void setColorTableEntry(int index , const ColorEntry& entry);
@@ -95,6 +97,10 @@ public:
      * See getColorTable()
      */
     ColorEntry colorEntry(int index , uint randomSeed = 0) const;
+
+    Q_INVOKABLE QColor getColor(int index) const;
+    Q_INVOKABLE void setColor(int index, QColor color);
+    Q_SIGNAL void colorChanged(int index);
 
     /**
      * Convenience method.  Returns the
@@ -126,12 +132,13 @@ public:
      *
      * TODO: More documentation
      */
-    void setOpacity(qreal opacity);
+    Q_INVOKABLE void setOpacity(qreal opacity);
     /**
      * Returns the opacity level for this color scheme, see setOpacity()
      * TODO: More documentation
      */
-    qreal opacity() const;
+    Q_INVOKABLE qreal opacity() const;
+    Q_SIGNAL void opacityChanged();
 
     /**
      * Enables randomization of the background color.  This will cause
@@ -177,6 +184,7 @@ private:
     void writeColorEntry(KConfig& config , const QString& colorName, const ColorEntry& entry,const RandomizationRange& range) const;
 #endif
     void readColorEntry(QSettings *s, int index);
+    void writeColorEntry(QSettings *s, int index, const ColorEntry& entry) const;
 
     // sets the amount of randomization allowed for a particular color
     // in the palette.  creates the randomization table if
@@ -221,8 +229,10 @@ public:
  * Manages the color schemes available for use by terminal displays.
  * See ColorScheme
  */
-class ColorSchemeManager
+class ColorSchemeManager : public QObject
 {
+    Q_OBJECT
+
 public:
 
     /**
@@ -251,7 +261,7 @@ public:
      * The first time that a color scheme with a particular name is
      * requested, the configuration information is loaded from disk.
      */
-    const ColorScheme* findColorScheme(const QString& name);
+    Q_INVOKABLE const Konsole::ColorScheme* findColorScheme(const QString& name);
 
 #if 0
     /**
@@ -291,7 +301,7 @@ public:
      * @param[in] path The path to KDE 4 .colorscheme or KDE 3 .schema.
      * @return Whether the color scheme is loaded successfully.
      */
-    bool loadCustomColorScheme(const QString& path);
+    Q_INVOKABLE bool loadCustomColorScheme(const QString& path);
 
     /**
      * @brief Allows to add a custom location of color schemes.

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3582,6 +3582,13 @@ int TerminalDisplay::getScrollbarValue()
     return _scrollBar->value();
 }
 
+void TerminalDisplay::setScrollbarValue(int value)
+{
+    if (value != _scrollBar->value()) {
+        _scrollBar->setValue(value);
+    }
+}
+
 int TerminalDisplay::getScrollbarMaximum()
 {
     return _scrollBar->maximum();

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2877,6 +2877,15 @@ void TerminalDisplay::pasteSelection()
   emitSelection(true,false);
 }
 
+bool TerminalDisplay::isClipboardEmpty()
+{
+    return QApplication::clipboard()->text().isEmpty();
+}
+
+bool TerminalDisplay::isSelectionEmpty()
+{
+    return _screenWindow->selectedText(_preserveLineBreaks).isEmpty();
+}
 
 void TerminalDisplay::setConfirmMultilinePaste(bool confirmMultilinePaste) {
     _confirmMultilinePaste = confirmMultilinePaste;

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -162,13 +162,22 @@ void TerminalDisplay::setBackgroundColor(const QColor& color)
       // Avoid propagating the palette change to the scroll bar
       _scrollBar->setPalette( QApplication::palette() );
 
+    emit backgroundColorChanged();
     update();
 }
 void TerminalDisplay::setForegroundColor(const QColor& color)
 {
     _colorTable[DEFAULT_FORE_COLOR].color = color;
-
+    emit foregroundColorChanged();
     update();
+}
+QColor TerminalDisplay::backgroundColor() const
+{
+    return _colorTable[DEFAULT_BACK_COLOR].color;
+}
+QColor TerminalDisplay::foregroundColor() const
+{
+    return _colorTable[DEFAULT_FORE_COLOR].color;
 }
 void TerminalDisplay::setColorTable(const ColorEntry table[])
 {
@@ -176,6 +185,7 @@ void TerminalDisplay::setColorTable(const ColorEntry table[])
       _colorTable[i] = table[i];
 
   setBackgroundColor(_colorTable[DEFAULT_BACK_COLOR].color);
+  setForegroundColor(_colorTable[DEFAULT_FORE_COLOR].color);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -94,6 +94,8 @@ class KONSOLEPRIVATE_EXPORT TerminalDisplay : public QQuickPaintedItem
    Q_PROPERTY(KSession* session         READ getSession      WRITE setSession     NOTIFY sessionChanged          )
    Q_PROPERTY(QFont font                READ getVTFont       WRITE setVTFont      NOTIFY vtFontChanged           )
    Q_PROPERTY(QString colorScheme       READ colorScheme     WRITE setColorScheme NOTIFY colorSchemeChanged      )
+   Q_PROPERTY(QColor backgroundColor    READ backgroundColor                      NOTIFY backgroundColorChanged  )
+   Q_PROPERTY(QColor foregroundColor    READ foregroundColor                      NOTIFY foregroundColorChanged  )
    Q_PROPERTY(QSize terminalSize        READ getTerminalSize                      NOTIFY changedContentSizeSignal)
    Q_PROPERTY(int lineSpacing           READ lineSpacing     WRITE setLineSpacing NOTIFY lineSpacingChanged      )
    Q_PROPERTY(bool terminalUsesMouse    READ getUsesMouse                         NOTIFY usesMouseChanged        )
@@ -564,6 +566,9 @@ public slots:
      */
     void setForegroundColor(const QColor& color);
 
+    QColor backgroundColor() const;
+    QColor foregroundColor() const;
+    
     void selectionChanged();
 
     // QMLTermWidget
@@ -637,6 +642,8 @@ signals:
     void lineSpacingChanged();
     void availableColorSchemesChanged();
     void colorSchemeChanged();
+    void backgroundColorChanged();
+    void foregroundColorChanged();
     void fullCursorHeightChanged();
     void blinkingCursorStateChanged();
     void boldIntenseChanged();

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -717,6 +717,7 @@ protected slots:
     //Renables bell noises and visuals.  Used to disable further bells for a short period of time
     //after emitting the first in a sequence of bell events.
     void enableBell();
+    void applyColorScheme();
 
 private slots:
 
@@ -893,6 +894,7 @@ private:
 
     uint _lineSpacing;
     QString _colorScheme;
+    const ColorScheme* _colorSchemeRef;
     bool _colorsInverted; // true during visual bell
 
     QSize _size;

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -101,7 +101,7 @@ class KONSOLEPRIVATE_EXPORT TerminalDisplay : public QQuickPaintedItem
    Q_PROPERTY(bool terminalUsesMouse    READ getUsesMouse                         NOTIFY usesMouseChanged        )
    Q_PROPERTY(int lines                 READ lines                                NOTIFY changedContentSizeSignal)
    Q_PROPERTY(int columns               READ columns                              NOTIFY changedContentSizeSignal)
-   Q_PROPERTY(int scrollbarCurrentValue READ getScrollbarValue                    NOTIFY scrollbarParamsChanged  )
+   Q_PROPERTY(int scrollbarCurrentValue READ getScrollbarValue WRITE setScrollbarValue NOTIFY scrollbarParamsChanged  )
    Q_PROPERTY(int scrollbarMaximum      READ getScrollbarMaximum                  NOTIFY scrollbarParamsChanged  )
    Q_PROPERTY(int scrollbarMinimum      READ getScrollbarMinimum                  NOTIFY scrollbarParamsChanged  )
    Q_PROPERTY(QSize fontMetrics         READ getFontMetrics                       NOTIFY changedFontMetricSignal )
@@ -956,6 +956,8 @@ private:
     bool getUsesMouse();
 
     int getScrollbarValue();
+    void setScrollbarValue(int value);
+
     int getScrollbarMaximum();
     int getScrollbarMinimum();
 

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -504,7 +504,13 @@ public slots:
      */
     void pasteSelection();
 
-    /**
+    /** Checks if the clipboard is empty */
+    bool isClipboardEmpty();
+
+    /** Checks if the selection is empty */
+    bool isSelectionEmpty();
+
+    /** 
        * Changes whether the flow control warning box should be shown when the flow control
        * stop key (Ctrl+S) are pressed.
        */

--- a/src/qmltermwidget_plugin.cpp
+++ b/src/qmltermwidget_plugin.cpp
@@ -1,5 +1,6 @@
 #include "qmltermwidget_plugin.h"
 
+#include "ColorScheme.h"
 #include "TerminalDisplay.h"
 #include "ksession.h"
 
@@ -9,11 +10,21 @@
 
 using namespace Konsole;
 
+static QObject *colorschememanager_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+
+    return ColorSchemeManager::instance();
+}
+
 void QmltermwidgetPlugin::registerTypes(const char *uri)
 {
     // @uri org.qterminal.qmlterminal
     qmlRegisterType<TerminalDisplay>(uri, 1, 0, "QMLTermWidget");
     qmlRegisterType<KSession>(uri, 1, 0, "QMLTermSession");
+    qmlRegisterUncreatableType<const Konsole::ColorScheme>(uri, 1, 0, "ColorScheme", QStringLiteral("Not instantiatable"));
+    qmlRegisterSingletonType<ColorSchemeManager>(uri, 1, 0, "ColorSchemeManager", colorschememanager_provider);
 }
 
 void QmltermwidgetPlugin::initializeEngine(QQmlEngine *engine, const char *uri)


### PR DESCRIPTION
I am working on modernizing lomiri-terminal-app which is a continuation of the ubuntu-terminal-app from Ubuntu Touch and now part of the Lomiri project. ubuntu-terminal-app is built on a heavily modified, vendored fork of qmltermwidget from the lxqt project. Rather than maintaining this in parallel we'd rather prefer to join forces, particularly since this fork of qmltermwidget is already packaged in major distributions. This PR exposes some additional functionality to QML in order to make  lomiri-terminal-app work with qmltermwidget. The most important change is the exposition of `ColorSchemeManager` and `ColorScheme` since we provide a QML-based color scheme editor as part of our settings dialogue. We are also using our own scrollbar based on our own QML components library. Finally, we need some additional clipboard/selection functionality in order to show popovers on paste.