### PR TITLE
Support multiple color scheme dirs

### DIFF
--- a/lib/tools.cpp
+++ b/lib/tools.cpp
@@ -54,7 +54,7 @@ void add_custom_color_scheme_dir(const QString& custom_dir)
 }
 
 /*! Helper function to get possible locations of color schemes.
-By default the COLORSCHEMES_DIR is used (linux/BSD/macports).
+By default the COLORSCHEMES_DIRS is used (linux/BSD/macports).
 But in some cases (apple bundle) there can be more locations).
 */
 const QStringList get_color_schemes_dirs()
@@ -62,13 +62,15 @@ const QStringList get_color_schemes_dirs()
 //    qDebug() << __FILE__ << __FUNCTION__;
 
     QStringList rval;
-    QString k(qgetenv("COLORSCHEMES_DIR"));
-    QDir d(k);
+    QDir d;
 
-//    qDebug() << "default COLORSCHEMES_DIR: " << k;
+    QString dirs(qgetenv("COLORSCHEMES_DIRS"));
+    for (auto dirname : dirs.split(":")) {
+        d.setPath(dirname);
 
-    if (d.exists())
-        rval << k.append(QLatin1Char('/'));
+        if (d.exists())
+            rval << dirname.append(QLatin1Char('/'));
+    }
 
 #ifdef Q_OS_MAC
     // subdir in the app location

--- a/src/qmltermwidget_plugin.cpp
+++ b/src/qmltermwidget_plugin.cpp
@@ -33,6 +33,13 @@ void QmltermwidgetPlugin::initializeEngine(QQmlEngine *engine, const char *uri)
         }
 
         setenv("KB_LAYOUT_DIR",kbl.toUtf8().constData(),1);
-        setenv("COLORSCHEMES_DIR",cs.toUtf8().constData(),1);
+
+        auto colorschemes = cs.toUtf8();
+
+        if (auto dirs = getenv("COLORSCHEMES_DIRS")) {
+            colorschemes.push_back(':');
+            colorschemes.append(dirs);
+        }
+        setenv("COLORSCHEMES_DIRS",colorschemes.constData(),1);
     }
 }


### PR DESCRIPTION
Currently, there's no way for an application user to _add_ custom color
schemes, since only the first of QML_INCLUDE_DIRS that includes the
colorschemes dir is chosen, and COLORSCHEMES_DIR is overwritten inside
the app. Use a colon-separated COLORSCHEMES_DIRS instead, which allows
to set multiple dirs for color schemes.
