### PR TITLE
Fix Qt 6.10 rendering problems

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -472,9 +472,7 @@ TerminalDisplay::TerminalDisplay(QQuickItem *parent)
   _scrollBar->setVisible(false);
   connect(_scrollBar, SIGNAL(valueChanged(int)), this, SIGNAL(scrollbarParamsChanged(int)));
 
-  // Qt 6.10 compatibility fix: Use Image rendering instead of FramebufferObject.
-  // Tradeoff is performance decrease.
-  setRenderTarget(QQuickPaintedItem::Image);
+  setUseFBORendering(true);
 
 //  setFocusPolicy( Qt::WheelFocus );
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -472,9 +472,9 @@ TerminalDisplay::TerminalDisplay(QQuickItem *parent)
   _scrollBar->setVisible(false);
   connect(_scrollBar, SIGNAL(valueChanged(int)), this, SIGNAL(scrollbarParamsChanged(int)));
 
-  // TODO Forcing rendering to Framebuffer. We need to determine if this is ok
-  // always or if we need to make this customizable.
-  setRenderTarget(QQuickPaintedItem::FramebufferObject);
+  // Qt 6.10 compatibility fix: Use Image rendering instead of FramebufferObject.
+  // Tradeoff is performance decrease.
+  setRenderTarget(QQuickPaintedItem::Image);
 
 //  setFocusPolicy( Qt::WheelFocus );
 

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -112,6 +112,7 @@ class KONSOLEPRIVATE_EXPORT TerminalDisplay : public QQuickPaintedItem
    Q_PROPERTY(bool blinkingCursor       READ blinkingCursor   WRITE setBlinkingCursor NOTIFY blinkingCursorStateChanged)
    Q_PROPERTY(bool antialiasText        READ antialias       WRITE setAntialias)
    Q_PROPERTY(QStringList availableColorSchemes READ availableColorSchemes NOTIFY availableColorSchemesChanged)
+   Q_PROPERTY(bool useFBORendering      READ useFBORendering WRITE setUseFBORendering)
 
 public:
     /** Constructs a new terminal display widget with the specified parent. */
@@ -400,6 +401,24 @@ public:
      * Returns true if anti-aliasing of text in the terminal is enabled.
      */
     static bool antialias()                 { return _antialiasText;   }
+
+    /**
+     * Sets whether to use FramebufferObject rendering (true) or Image rendering (false).
+     * FramebufferObject is GPU-based and more performant.
+     * Image rendering is CPU-based and causes higher CPU usage, but can solve rendering issues.
+     */
+    void setUseFBORendering(bool useFBO) { 
+        _useFBORendering = useFBO;
+        QQuickPaintedItem::RenderTarget target = useFBO ?
+            QQuickPaintedItem::FramebufferObject : QQuickPaintedItem::Image;
+
+        QQuickPaintedItem::setRenderTarget(target);
+    }
+
+    /**
+     * Returns true if using FramebufferObject rendering, false if using Image.
+     */
+    bool useFBORendering() const { return _useFBORendering; }
 
     /**
      * Specify whether line chars should be drawn by ourselves or left to
@@ -834,6 +853,7 @@ private:
     bool _drawTextTestFlag;         // indicates when text drawing metrics are being tested
     bool _boldIntense;   // Whether intense colors should be rendered with bold font
     bool _italicEnabled; // Whether italic rendition is allowed
+    bool _useFBORendering; // Whether to use FramebufferObject (true) or Image (false)
 
     int _leftMargin;    // offset
     int _topMargin;    // offset


### PR DESCRIPTION
I would have opened an issue but they are maybe not enabled in this project.

I have big problems with Qt 6.10 (6.8 worked fine) where rendering gets messed up. Foreground / font colored block will cover 1/3 of the terminal and most of text (or sometimes all). And with lots of lines, text gets written on top of old text.

I know you recently finished moving to Qt 6, and this isn't related to those changes since this problem appeared even when I was using Qt6 support from https://github.com/Swordfish90/qmltermwidget/pull/44.

I found out that the problem can be solved with `setRenderTarget(QQuickPaintedItem::Image);` and that's what this PR does. Not sure if this should be merged as is, but this can provide a starting point for solving this.