### PR TITLE
Fix opacity not applying to text fragment backgrounds

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -178,7 +178,6 @@ void TerminalDisplay::setBackgroundColor(const QColor& color)
 
     update();
 }
-
 void TerminalDisplay::setForegroundColor(const QColor& color)
 {
     _colorTable[DEFAULT_FORE_COLOR].color = color;
@@ -960,7 +959,7 @@ void TerminalDisplay::drawTextFragment(QPainter& painter ,
     // draw background if different from the display's background color
     if ( backgroundColor != palette().window().color() )
         drawBackground(painter,rect,backgroundColor,
-                       true /* use transparency */);
+                       false /* do not use transparency */);
 
     // draw cursor shape if the current character is the cursor
     // this may alter the foreground and background colors

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -178,6 +178,7 @@ void TerminalDisplay::setBackgroundColor(const QColor& color)
 
     update();
 }
+
 void TerminalDisplay::setForegroundColor(const QColor& color)
 {
     _colorTable[DEFAULT_FORE_COLOR].color = color;
@@ -760,6 +761,7 @@ QColor TerminalDisplay::keyboardCursorColor() const
 void TerminalDisplay::setOpacity(qreal opacity)
 {
     _opacity = qBound(static_cast<qreal>(0), opacity, static_cast<qreal>(1));
+    update();
 }
 
 void TerminalDisplay::setBackgroundImage(const QString& backgroundImage)
@@ -958,7 +960,7 @@ void TerminalDisplay::drawTextFragment(QPainter& painter ,
     // draw background if different from the display's background color
     if ( backgroundColor != palette().window().color() )
         drawBackground(painter,rect,backgroundColor,
-                       false /* do not use transparency */);
+                       true /* use transparency */);
 
     // draw cursor shape if the current character is the cursor
     // this may alter the foreground and background colors

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -134,9 +134,6 @@ public:
      */
     uint randomSeed() const;
 
-    /** Sets the opacity of the terminal display. */
-    void setOpacity(qreal opacity);
-
     /** 
      * This enum describes the location where the scroll bar is positioned in the display widget.
      */
@@ -595,6 +592,9 @@ public slots:
      * @see setColorTable(), setForegroundColor()
      */
     void setBackgroundColor(const QColor& color);
+
+    /** Sets the opacity of the terminal display. */
+    void setOpacity(qreal opacity);
 
     /**
      * Sets the text of the display to the specified color.


### PR DESCRIPTION
## Summary

- Move `setOpacity` from `public:` to `public slots:` so it can be
  called from QML and connected to signals
- Add `update()` to `setOpacity` so changing opacity triggers a repaint
- Pass `useOpacitySetting=true` in `drawTextFragment` so text cells with
  non-default background colors (e.g. highlighted text, colored output)
  also respect the configured opacity level — previously only the default
  background was affected

## Before and after on my custom terminal widget on quickshell:
### BEFORE:
<img width="469" height="1078" alt="image" src="https://github.com/user-attachments/assets/c8fcfee8-78ee-4564-ae39-61cf2914b430" />

### AFTER:
<img width="460" height="1078" alt="image" src="https://github.com/user-attachments/assets/56ebc34e-be0b-49d7-ac9e-6c1afe23d247" />



## Test plan

- [ ] Set a sub-1.0 opacity value via `setOpacity()` and confirm the
      terminal background renders semi-transparent
- [ ] Run a command that produces colored output (e.g. `ls --color`) and
      confirm the colored cell backgrounds are also semi-transparent, not
      opaque
- [ ] Confirm that full-opacity (`1.0`) rendering is unchanged — no
      visual difference from before
- [ ] Connect `setOpacity` to a QML signal and confirm it fires correctly
      without needing a manual `update()` call


